### PR TITLE
fix normal http based rules

### DIFF
--- a/aws/asg/alb.tf
+++ b/aws/asg/alb.tf
@@ -68,5 +68,5 @@ resource "aws_lb_listener_rule" "static" {
 
 resource "aws_autoscaling_attachment" "asg" {
   autoscaling_group_name = aws_autoscaling_group.asg.name
-  lb_target_group_arn = aws_lb_target_group.http.arn
+  lb_target_group_arn    = aws_lb_target_group.http.arn
 }

--- a/aws/asg/asg.tf
+++ b/aws/asg/asg.tf
@@ -1,8 +1,8 @@
 resource "aws_launch_template" "template" {
-  image_id      = var.ami
-  instance_type = "t3.nano"
-  user_data     = filebase64("userdata.tpl")
-  vpc_security_group_ids = [ aws_security_group.allow_http.id ]
+  image_id               = var.ami
+  instance_type          = "t3.nano"
+  user_data              = filebase64("userdata.tpl")
+  vpc_security_group_ids = [aws_security_group.allow_http.id]
 }
 
 resource "aws_autoscaling_group" "asg" {
@@ -31,4 +31,4 @@ resource "aws_autoscaling_group" "asg" {
     triggers = ["tag"]
   }
 }
-  
+

--- a/aws/asg/security_group.tf
+++ b/aws/asg/security_group.tf
@@ -4,11 +4,11 @@ resource "aws_security_group" "allow_http" {
   vpc_id      = var.vpc
 
   ingress {
-    description      = "Open HTTP"
-    from_port        = 80
-    to_port          = 80
-    protocol         = "tcp"
-    cidr_blocks      = [ "0.0.0.0/0" ]
+    description = "Open HTTP"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   egress {

--- a/aws/asg/variable.tf
+++ b/aws/asg/variable.tf
@@ -21,8 +21,8 @@ variable "ami" {
   default = "ami-0efcece6bed30fd98"
 }
 variable "availability_zones" {
-  type = list(string)
-  default = [ "us-west-2c","us-west-2b" ]
+  type    = list(string)
+  default = ["us-west-2c", "us-west-2b"]
 }
 variable "hostedzone" {
   type    = string

--- a/aws/ec2/ec2.tf
+++ b/aws/ec2/ec2.tf
@@ -21,8 +21,6 @@ resource "aws_instance" "ec2" {
   user_data              = file("userdata.tpl")
   vpc_security_group_ids = [aws_security_group.allow_http.id]
   subnet_id              = var.ec2_subnet
-  iam_instance_profile   = "ssm"
-  key_name               = "riley"
   tags = {
     Name = "${local.name}-instance"
   }

--- a/aws/ec2/ec2.tf
+++ b/aws/ec2/ec2.tf
@@ -1,10 +1,28 @@
 # Create instance that serves traffic on port 80 (nginx)
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
 resource "aws_instance" "ec2" {
-  ami                    = var.ami
+  ami                    = var.ami != null ? var.ami : data.aws_ami.ubuntu.image_id
   instance_type          = "t3.micro"
   user_data              = file("userdata.tpl")
   vpc_security_group_ids = [aws_security_group.allow_http.id]
   subnet_id              = var.ec2_subnet
+  iam_instance_profile   = "ssm"
+  key_name               = "riley"
   tags = {
     Name = "${local.name}-instance"
   }

--- a/aws/ec2/main.tf
+++ b/aws/ec2/main.tf
@@ -1,7 +1,7 @@
 locals {
   name = var.name == null ? random_pet.name.id : lower(var.name)
   # use route53 domain if given, otherwise fallback to default ALB DNS name
-  lb_hostname = var.hostedzone == null ? aws_lb.alb[0].dns_name : "${local.name}.${data.aws_route53_zone.zone[0].name}"
+  lb_hostname = var.alb_route53_dns_name != null ? var.alb_route53_dns_name : var.hostedzone == null ? aws_lb.alb[0].dns_name : "${local.name}.${data.aws_route53_zone.zone[0].name}"
   tags = {
     lb_hostname = local.lb_hostname
   }

--- a/aws/ec2/output.tf
+++ b/aws/ec2/output.tf
@@ -1,19 +1,19 @@
 output "name" {
-  value = local.name
+  value       = local.name
   description = "Name of the ec2 instance"
 }
 
 output "ec2" {
-  value = aws_instance.ec2.arn
+  value       = aws_instance.ec2.arn
   description = "ARN of the ec2 instance"
 }
 
 output "rule" {
-  value = "https://app.harness.io/ng/account/${data.harness_platform_current_account.current.id}/ce/autostopping-rules/rule/${harness_autostopping_rule_vm.rule.id}"
+  value       = "https://app.harness.io/ng/account/${data.harness_platform_current_account.current.id}/ce/autostopping-rules/rule/${harness_autostopping_rule_vm.rule.id}"
   description = "Link to autostopping rule in Harness"
 }
 
 output "url" {
-  value = harness_autostopping_rule_vm.rule.custom_domains[0]
+  value       = harness_autostopping_rule_vm.rule.custom_domains[0]
   description = "URL for the application"
 }

--- a/aws/ec2/readme.md
+++ b/aws/ec2/readme.md
@@ -20,6 +20,57 @@ Provision an EC2 instance, alb, and create an autostopping rule for the instance
 
 ![image](https://github.com/wings-software/AutoStoppingLab/assets/7338312/ab1a3163-3657-4244-833b-7e8ccb4b176b)
 
+### Patterns
+
+#### http
+
+create an ec2, alb, and autostopping rule using http and the default alb dns name:
+```
+region = "us-west-2"
+
+# common networking
+vpc = "vpc-02767cb7b8b634d54"
+
+# ec2 instance
+ec2_subnet = "subnet-022b0cf63cfa2b43e"
+
+# alb
+alb_subnets = ["subnet-0afa8a1877a19c619", "subnet-08515090d18fe4e56"]
+
+#harness
+harness_cloud_connector_id = "harness_impeng_play_ccm"
+```
+
+to use a custom domain, simple pass your route53 hosted zone id:
+```
+hostedzone = "Z00081583ARZJ9LTKZHRI"
+```
+
+#### https
+
+create an ec2, alb, and autostopping rule using http and https using a custom domain:
+```
+region = "us-west-2"
+
+# common networking
+vpc = "vpc-02767cb7b8b634d54"
+
+# ec2 instance
+ec2_subnet = "subnet-022b0cf63cfa2b43e"
+
+# alb
+alb_subnets = ["subnet-0afa8a1877a19c619", "subnet-08515090d18fe4e56"]
+
+# https information
+alb_certificate_arn = "arn:aws:acm:us-west-2:664418987337:certificate/bfb75fd2-a1d5-4de4-ab86-b2bc36983097"
+alb_route53_dns_name = "asec2albtest.isehrns.rileysnyder.dev"
+
+#harness
+harness_cloud_connector_id = "harness_impeng_play_ccm"
+```
+
+This requires that you have a certificate already created for the `alb_route53_dns_name` domain in your account
+
 ## Requirements
 
 | Name | Version |

--- a/aws/ec2/rule.tf
+++ b/aws/ec2/rule.tf
@@ -1,3 +1,15 @@
+locals {
+  http = {
+    protocol = "http"
+    port     = "80"
+  }
+  https = {
+    protocol = "https"
+    port     = "443"
+  }
+  rule_routing = var.alb_certificate_arn != null ? [local.http, local.https] : [local.http]
+}
+
 # Import ALB and create autostopping rule
 resource "harness_autostopping_aws_alb" "harness_alb" {
   name               = "${local.name}-lb"
@@ -10,7 +22,7 @@ resource "harness_autostopping_aws_alb" "harness_alb" {
   # setting hosted zone is not needed when route53 is already set up externally
   # route53_hosted_zone_id            = "/hostedzone/${var.hostedzone}"
   delete_cloud_resources_on_destroy = false
-  certificate_id = var.alb_certificate_arn
+  certificate_id                    = var.alb_certificate_arn
 }
 
 resource "harness_autostopping_rule_vm" "rule" {
@@ -23,19 +35,15 @@ resource "harness_autostopping_rule_vm" "rule" {
   }
   http {
     proxy_id = harness_autostopping_aws_alb.harness_alb.identifier
-    routing {
-      source_protocol = "http"
-      target_protocol = "http"
-      source_port     = 80
-      target_port     = 80
-      action          = "forward"
-    }
-    routing {
-      source_protocol = "https"
-      target_protocol = "https"
-      source_port     = 443
-      target_port     = 443
-      action          = "forward"
+    dynamic "routing" {
+      for_each = local.rule_routing
+      content {
+        source_protocol = routing.value["protocol"]
+        target_protocol = routing.value["protocol"]
+        source_port     = routing.value["port"]
+        target_port     = routing.value["port"]
+        action          = "forward"
+      }
     }
     health {
       protocol         = "http"

--- a/aws/ec2/userdata.tpl
+++ b/aws/ec2/userdata.tpl
@@ -8,17 +8,17 @@ sudo apt-get install -y nginx openssl
 sudo openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
   -keyout /etc/ssl/private/nginx-selfsigned.key \
   -out /etc/ssl/certs/nginx-selfsigned.crt \
-  -subj "/CN=$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)"
+  -subj "/CN=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)"
 
 # Write nginx config with HTTP 200 message and HTTPS static file
-sudo tee /etc/nginx/sites-available/default > /dev/null <<'EOF'
+sudo tee /etc/nginx/conf.d/default.conf > /dev/null <<'EOF'
 server {
     listen 80 default_server;
     listen [::]:80 default_server;
     server_name _;
 
     location / {
-        return 200 'Hello from Nginx over HTTPS port 80';
+        return 200 'Hello from Nginx over HTTP port 80';
         add_header Content-Type text/plain;
     }
 }
@@ -31,11 +31,9 @@ server {
     ssl_certificate /etc/ssl/certs/nginx-selfsigned.crt;
     ssl_certificate_key /etc/ssl/private/nginx-selfsigned.key;
 
-    root /var/www/html;
-    index index.html;
-
     location / {
-        try_files $uri $uri/ =404;
+        return 200 'Hello from Nginx over HTTPS port 443';
+        add_header Content-Type text/plain;
     }
 }
 EOF
@@ -43,6 +41,9 @@ EOF
 # Create HTTPS content
 echo "Hello from Nginx over HTTPS port 443" | sudo tee /var/www/html/index.html
 sudo chown www-data:www-data /var/www/html/index.html
+
+# Remove default site
+rm /etc/nginx/sites-enabled/default
 
 # Test and reload nginx
 sudo nginx -t && sudo systemctl reload nginx

--- a/aws/ec2/variable.tf
+++ b/aws/ec2/variable.tf
@@ -48,14 +48,14 @@ variable "harness_cloud_connector_id" {
   default = "AWS CCM connector for target AWS account"
 }
 
-variable alb_certificate_arn {
-  type = string
+variable "alb_certificate_arn" {
+  type        = string
   description = "Alb certificate ARN"
-  default = null
+  default     = null
 }
 
-variable alb_route53_dns_name {
-  type = string
+variable "alb_route53_dns_name" {
+  type        = string
   description = "alb dns name added in route 53"
-  default = null
+  default     = null
 }

--- a/azure/provider.tf
+++ b/azure/provider.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     harness = {
-      source = "harness/harness"
+      source  = "harness/harness"
       version = "0.28.3"
     }
   }

--- a/azure/rule.tf
+++ b/azure/rule.tf
@@ -14,8 +14,8 @@ resource "harness_autostopping_rule_vm" "vm" {
   cloud_connector_id = var.cloud_connector_id
   idle_time_mins     = 10
   filter {
-    vm_ids  = ["/subscriptions/${var.subscription_id}/resourceGroups/${var.resource_group}/providers/Microsoft.Compute/virtualMachines/${var.instance_id}"
-]
+    vm_ids = ["/subscriptions/${var.subscription_id}/resourceGroups/${var.resource_group}/providers/Microsoft.Compute/virtualMachines/${var.instance_id}"
+    ]
     regions = [var.region]
   }
   http {
@@ -36,5 +36,5 @@ resource "harness_autostopping_rule_vm" "vm" {
       status_code_to   = 299
     }
   }
-  custom_domains = [ "35.239.247.160.nip.io" ]
+  custom_domains = ["35.239.247.160.nip.io"]
 }

--- a/gcp/provider.tf
+++ b/gcp/provider.tf
@@ -7,8 +7,8 @@ terraform {
   }
 }
 provider "google" {
-  project     = "ccm-play"
-  region      = "us-central1"
+  project = "ccm-play"
+  region  = "us-central1"
 }
 provider "harness" {
   account_id       = var.account_id

--- a/gcp/rule.tf
+++ b/gcp/rule.tf
@@ -37,5 +37,5 @@ resource "harness_autostopping_rule_vm" "vm" {
       status_code_to   = 299
     }
   }
-  custom_domains = [ "35.239.247.160.nip.io" ]
+  custom_domains = ["35.239.247.160.nip.io"]
 }

--- a/k8s/provider.tf
+++ b/k8s/provider.tf
@@ -1,5 +1,5 @@
 provider "kubernetes" {
-  config_path    = "~/.kube/config"
+  config_path = "~/.kube/config"
 }
 provider "kubectl" {
   apply_retry_count = 15

--- a/k8s/rule.tf
+++ b/k8s/rule.tf
@@ -1,4 +1,4 @@
 resource "kubectl_manifest" "rule" {
-  yaml_body = file("rule.yaml")
+  yaml_body       = file("rule.yaml")
   validate_schema = false
 }

--- a/k8s/variables.tf
+++ b/k8s/variables.tf
@@ -1,12 +1,12 @@
 variable "namespace" {
-  type = string
+  type    = string
   default = "default"
 }
 variable "name" {
-  type = string
+  type    = string
   default = "tf-test"
 }
 variable "k8s_connector_id" {
-    type = string
-    default = "nknautostoptest"
+  type    = string
+  default = "nknautostoptest"
 }


### PR DESCRIPTION
`data "aws_ami" "ubuntu" {`
use a data resource to get the AMI in whatever region people are using

generate routing config for rule based on if https is used, before we were defining https no matter what when the user may only do http

dont use the public ip for the cert, and users will most likley put the machine in a private subnet, so use the private ip
also remove /etc/nginx/sites-enabled/default from the machine as this was causing conflicts for me

add some readme information on example of variables to pass when using http or https